### PR TITLE
Add a security policy (community standards)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security policy
+
+Thanks for helping make `otp_builds` safer for everyone.
+
+Find below updated information on our security policy.
+
+## Security
+
+We take the security of this software seriously.
+
+We don't implement a bug bounty program or bounty rewards, but will work with
+you to ensure that your findings get the appropriate handling.
+
+## Reporting Security Issues
+
+If you believe you have found a security vulnerability in this repository,
+please report it to <bryan.paxton@erlef.org>.
+
+Please do not report security vulnerabilities through public channels, like
+GitHub issues, discussions, or pull requests.
+
+Please include as much of the information listed below as you can to help us
+better understand and resolve the issue:
+
+- the type of issue (e.g., buffer overflow, SQL injection, or cross-site
+  scripting)
+- full paths of source file(s) related to the manifestation of the issue
+- the location of the affected source code (tag/branch/commit or direct URL)
+- any special configuration required to reproduce the issue
+- step-by-step instructions to reproduce the issue
+- proof-of-concept or exploit code (if possible)
+- impact of the issue, including how an attacker might exploit the issue
+
+This information will help us triage your report more quickly.


### PR DESCRIPTION
Copied, as-is, from https://github.com/erlef/setup-beam/blob/main/SECURITY.md.

Closes #17 