### PR TITLE
Add "code" (shell) linter and format checker

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -22,4 +22,12 @@ jobs:
       - name: ShellCheck
         uses: luizm/action-sh-checker@v0.9.0
         env:
-          SHFMT_OPTS: -i 4 -d
+          SHFMT_OPTS: -i 2 -d
+
+      - uses: erlef/setup-beam@v1.18.2
+        with:
+          otp-version: 27
+          elixir-version: 1.17
+
+      - run: |
+          mix format --check-formatted scripts/*.exs

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -22,5 +22,4 @@ jobs:
       - name: ShellCheck
         uses: luizm/action-sh-checker@v0.9.0
         env:
-          SHELLCHECK_OPTS: -o all
           SHFMT_OPTS: -i 4 -d

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.7
 
-      - name: ShellCheck
+      - name: shell scripts check
         uses: luizm/action-sh-checker@v0.9.0
         env:
           SHFMT_OPTS: -i 2 -d
@@ -29,5 +29,6 @@ jobs:
           otp-version: 27
           elixir-version: 1.17
 
-      - run: |
+      - name: exs format check
+        run: |
           mix format --check-formatted scripts/*.exs

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,0 +1,26 @@
+---
+"on":
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - "*"
+  workflow_dispatch: {}
+
+name: Checks
+
+jobs:
+  checks:
+    name: Checks
+
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4.1.7
+
+      - name: ShellCheck
+        uses: luizm/action-sh-checker@v0.9.0
+        env:
+          SHELLCHECK_OPTS: -o all
+          SHFMT_OPTS: -i 4 -d

--- a/scripts/build_otp_macos.bash
+++ b/scripts/build_otp_macos.bash
@@ -52,7 +52,7 @@ build_openssl() {
     return
   fi
 
-  if [[ $version == 3* ]]; then
+  if [[ "$version" == 3* ]]; then
     local ref_name="openssl-${version}"
   else
     local ref_name="OpenSSL_${version//./_}"
@@ -66,6 +66,7 @@ build_openssl() {
   (
     cd "${src_dir}"
     git clean -dfx
+    # shellcheck disable=SC2086
     ./config no-shared --prefix="${rel_dir}" ${CFLAGS}
     make
     make install_sw
@@ -118,7 +119,7 @@ test_otp() {
     {ok, _} = application:ensure_all_started(crypto), io:format("crypto ok~n"),
     halt().'
 
-  if dyld_info ${OTP_DIR}/lib/crypto-*/priv/lib/crypto.so | tail -n +2 | grep -q openssl; then
+  if dyld_info "${OTP_DIR}/lib/crypto-*/priv/lib/crypto.so" | tail -n +2 | grep -q openssl; then
     echo "error: openssl dynamically linked"
     exit 1
   fi
@@ -128,7 +129,7 @@ test_otp() {
       wx:new(), io:format("wx ok~n"),
       halt().'
 
-    if dyld_info ${OTP_DIR}/lib/wx-*/priv/wxe_driver.so | tail -n +2 | grep -q wxwidgets; then
+    if dyld_info "${OTP_DIR}/lib/wx-*/priv/wxe_driver.so" | tail -n +2 | grep -q wxwidgets; then
       echo "error: wx dynamically linked"
       exit 1
     fi
@@ -188,7 +189,7 @@ build_otp() {
     fi
 
     if [[ "${WXWIDGETS_VERSION}" = disabled ]]; then
-      wxwidgets_flags=--without-{wx,observer,debugger,et}
+      wxwidgets_flags="--without-{wx,observer,debugger,et}"
     else
       wxwidgets_flags=""
     fi
@@ -206,6 +207,7 @@ build_otp() {
         ;;
     esac
 
+    # shellcheck disable=SC2086
     ./otp_build configure \
       --build="${target}" \
       --host="${target}" \
@@ -224,6 +226,7 @@ build_otp() {
 
   export PATH="${rel_dir}/bin:${PATH}"
 
+  # shellcheck disable=SC2310
   if ! test_otp; then
     rm -rf "${rel_dir}"
   fi
@@ -236,4 +239,5 @@ build_tgz() {
   tar czf "${OTP_TGZ}" --cd "${OTP_DIR}" .
 }
 
+# shellcheck disable=SC2068
 main $@

--- a/scripts/build_otp_macos.bash
+++ b/scripts/build_otp_macos.bash
@@ -13,11 +13,10 @@ EOF
   local ref_name=$1
 
   case "${ref_name}" in
-      OTP-25* | OTP-26.0* | OTP-26.1)
-          WXWIDGETS_VERSION=disabled
-          ;;
-      *)
-          ;;
+  OTP-25* | OTP-26.0* | OTP-26.1)
+    WXWIDGETS_VERSION=disabled
+    ;;
+  *) ;;
   esac
 
   : "${BUILD_DIR:=${PWD}/tmp/otp_builds}"
@@ -195,16 +194,16 @@ build_otp() {
     fi
 
     case "${arch}" in
-      x86_64)
-        target="x86_64-apple-darwin"
-        ;;
-      arm64)
-        target="aarch64-apple-darwin"
-        ;;
-      *)
-        echo "Unknown architecture: ${arch}"
-        exit 1
-        ;;
+    x86_64)
+      target="x86_64-apple-darwin"
+      ;;
+    arm64)
+      target="aarch64-apple-darwin"
+      ;;
+    *)
+      echo "Unknown architecture: ${arch}"
+      exit 1
+      ;;
     esac
 
     # shellcheck disable=SC2086

--- a/scripts/elixir-install.sh
+++ b/scripts/elixir-install.sh
@@ -8,16 +8,16 @@ main() {
 
   for arg in "$@"; do
     case "$arg" in
-      elixir@*)
-        elixir_version="${arg#elixir@}"
-        ;;
-      otp@*)
-        otp_version="${arg#otp@}"
-        ;;
-      *)
-        echo "error: invalid argument $arg" >&2
-        exit 1
-        ;;
+    elixir@*)
+      elixir_version="${arg#elixir@}"
+      ;;
+    otp@*)
+      otp_version="${arg#otp@}"
+      ;;
+    *)
+      echo "error: invalid argument $arg" >&2
+      exit 1
+      ;;
     esac
   done
 
@@ -27,9 +27,9 @@ main() {
 
   otp_release="${otp_version%%.*}"
 
-  if [ "${otp_version}" = "master" ] || \
-     [ "${otp_version}" = "latest" ] || \
-     echo "${otp_version}" | grep -q '^maint'; then
+  if [ "${otp_version}" = "master" ] ||
+    [ "${otp_version}" = "latest" ] ||
+    echo "${otp_version}" | grep -q '^maint'; then
     elixir_otp_release=27
   else
     elixir_otp_release=$otp_release
@@ -63,23 +63,23 @@ main() {
 install_otp() {
   os=$(uname -s)
   case "$os" in
-    Darwin) os=darwin ;;
-    Linux) os=linux ;;
-    MINGW64*) os=windows ;;
-    *) echo "error: unsupported OS: $os." && exit 1 ;;
+  Darwin) os=darwin ;;
+  Linux) os=linux ;;
+  MINGW64*) os=windows ;;
+  *) echo "error: unsupported OS: $os." && exit 1 ;;
   esac
 
   arch=$(uname -m)
   case "$arch" in
-    x86_64)
-      macos_target=x86_64-apple-darwin
-      linux_target=amd64
-      ;;
-    aarch64|arm64)
-      macos_target=aarch64-apple-darwin
-      linux_target=arm64
-      ;;
-    *) echo "error: unsupported architecture: $arch." && exit 1 ;;
+  x86_64)
+    macos_target=x86_64-apple-darwin
+    linux_target=amd64
+    ;;
+  aarch64 | arm64)
+    macos_target=aarch64-apple-darwin
+    linux_target=arm64
+    ;;
+  *) echo "error: unsupported architecture: $arch." && exit 1 ;;
   esac
 
   if [ ! -d "$otp_dir/bin" ]; then

--- a/scripts/update_builds.bash
+++ b/scripts/update_builds.bash
@@ -36,13 +36,13 @@ push() {
   git checkout "${target_branch}"
   git reset --hard "origin/${target_branch}"
   git pull origin "${target_branch}"
-  build_sha256=$(shasum -a 256 $TGZ | cut -d ' ' -f 1)
+  build_sha256=$(shasum -a 256 "$TGZ" | cut -d ' ' -f 1)
   date=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
   mkdir -p builds/
   touch "${BUILDS_CSV}"
   sed -i.bak "/^${OTP_REF_NAME},/d" "${BUILDS_CSV}"
   rm "${BUILDS_CSV}.bak"
-  echo -ne "${OTP_REF_NAME},${OTP_REF},${date},${build_sha256},openssl-${OPENSSL_VERSION},wxwidgets-${WXWIDGETS_VERSION}\n$(cat ${BUILDS_CSV})" > "${BUILDS_CSV}"
+  echo -ne "${OTP_REF_NAME},${OTP_REF},${date},${build_sha256},openssl-${OPENSSL_VERSION},wxwidgets-${WXWIDGETS_VERSION}\n$(cat "${BUILDS_CSV}")" > "${BUILDS_CSV}"
   sort --reverse --unique -k1,1 -o "${BUILDS_CSV}" "${BUILDS_CSV}"
   git add builds/
   GIT_AUTHOR_NAME="${GITHUB_ACTOR}" \
@@ -53,4 +53,5 @@ push() {
   git push origin "${target_branch}"
 }
 
+# shellcheck disable=SC2068
 main $@

--- a/scripts/update_builds.bash
+++ b/scripts/update_builds.bash
@@ -42,13 +42,13 @@ push() {
   touch "${BUILDS_CSV}"
   sed -i.bak "/^${OTP_REF_NAME},/d" "${BUILDS_CSV}"
   rm "${BUILDS_CSV}.bak"
-  echo -ne "${OTP_REF_NAME},${OTP_REF},${date},${build_sha256},openssl-${OPENSSL_VERSION},wxwidgets-${WXWIDGETS_VERSION}\n$(cat "${BUILDS_CSV}")" > "${BUILDS_CSV}"
+  echo -ne "${OTP_REF_NAME},${OTP_REF},${date},${build_sha256},openssl-${OPENSSL_VERSION},wxwidgets-${WXWIDGETS_VERSION}\n$(cat "${BUILDS_CSV}")" >"${BUILDS_CSV}"
   sort --reverse --unique -k1,1 -o "${BUILDS_CSV}" "${BUILDS_CSV}"
   git add builds/
   GIT_AUTHOR_NAME="${GITHUB_ACTOR}" \
-  GIT_AUTHOR_EMAIL="${GITHUB_ACTOR}@users.noreply.github.com" \
-  GIT_COMMITTER_NAME="github-actions[bot]" \
-  GIT_COMMITTER_EMAIL="github-actions[bot]@users.noreply.github.com" \
+    GIT_AUTHOR_EMAIL="${GITHUB_ACTOR}@users.noreply.github.com" \
+    GIT_COMMITTER_NAME="github-actions[bot]" \
+    GIT_COMMITTER_EMAIL="github-actions[bot]@users.noreply.github.com" \
     git commit -m "${BUILDS_CSV}: Add ${OTP_REF_NAME}"
   git push origin "${target_branch}"
 }

--- a/scripts/upload.bash
+++ b/scripts/upload.bash
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 usage() {
-  cat<<EOF
+  cat <<EOF
 ref_name=OTP-27.1.2; \
   OTP_REF_NAME="${ref_name}" \
   OPENSSL_VERSION=3.1.6 \
@@ -38,7 +38,7 @@ main() {
     else
       if ! echo "${ref_name}" | grep -qE 'maint|master'; then
         if [[ -f builds/aarch64-apple-darwin.csv ]]; then
-          latest_version=$(cut -d"," -f1 < builds/aarch64-apple-darwin.csv | grep OTP- | sed 's/OTP-//' | sort --reverse -V | head -1)
+          latest_version=$(cut -d"," -f1 <builds/aarch64-apple-darwin.csv | grep OTP- | sed 's/OTP-//' | sort --reverse -V | head -1)
           version=${ref_name/OTP-/}
 
           if [[ $(printf "%s\n%s" "$latest_version" "$version" | sort --reverse -V | head -1) != "$latest_version" ]]; then
@@ -62,18 +62,18 @@ main() {
 
   arch=$(uname -m)
   case "${arch}" in
-    x86_64)
-      target="x86_64-apple-darwin"
-      legacy_target="macos-amd64"
-      ;;
-    arm64)
-      target="aarch64-apple-darwin"
-      legacy_target="macos-arm64"
-      ;;
-    *)
-      echo "Unknown architecture: ${arch}"
-      exit 1
-      ;;
+  x86_64)
+    target="x86_64-apple-darwin"
+    legacy_target="macos-amd64"
+    ;;
+  arm64)
+    target="aarch64-apple-darwin"
+    legacy_target="macos-arm64"
+    ;;
+  *)
+    echo "Unknown architecture: ${arch}"
+    exit 1
+    ;;
   esac
 
   mkdir -p /tmp/otp_builds

--- a/scripts/upload.bash
+++ b/scripts/upload.bash
@@ -51,12 +51,13 @@ main() {
     # Initial commit
     target=b5893a3c3a8d0ab54be5d04de450b24d9e5aa149
 
+    # shellcheck disable=SC2086
     gh release create \
       --repo "${GITHUB_REPOSITORY}" \
       --title "${ref_name}" \
       --notes "${notes}" \
       --target "${target}" \
-      "${extra_flags}" \
+      ${extra_flags} \
       "${ref_name}"
   fi
 

--- a/scripts/upload.bash
+++ b/scripts/upload.bash
@@ -19,7 +19,7 @@ main() {
   : "${ATTESTATION:=}"
 
   if [[ -z "${OTP_REF+x}" ]]; then
-    OTP_REF=$(gh api repos/erlang/otp/commits/${OTP_REF_NAME} --jq .sha)
+    OTP_REF=$(gh api "repos/erlang/otp/commits/${OTP_REF_NAME}" --jq .sha)
   fi
 
   if [[ "${OTP_REF_NAME}" = master ]] || echo "${OTP_REF_NAME}" | grep -q "^maint"; then
@@ -38,8 +38,8 @@ main() {
     else
       if ! echo "${ref_name}" | grep -qE 'maint|master'; then
         if [[ -f builds/aarch64-apple-darwin.csv ]]; then
-          latest_version=`cat builds/aarch64-apple-darwin.csv | cut -d"," -f1 | grep OTP- | sed 's/OTP-//' | sort --reverse -V | head -1`
-          version=$(echo "$ref_name" | sed 's/OTP-//')
+          latest_version=$(cut -d"," -f1 < builds/aarch64-apple-darwin.csv | grep OTP- | sed 's/OTP-//' | sort --reverse -V | head -1)
+          version=${ref_name/OTP-/}
 
           if [[ $(printf "%s\n%s" "$latest_version" "$version" | sort --reverse -V | head -1) != "$latest_version" ]]; then
             extra_flags="--latest"
@@ -56,7 +56,7 @@ main() {
       --title "${ref_name}" \
       --notes "${notes}" \
       --target "${target}" \
-      ${extra_flags} \
+      "${extra_flags}" \
       "${ref_name}"
   fi
 
@@ -107,4 +107,5 @@ main() {
     --field target="${target}"
 }
 
+# shellcheck disable=SC2068
 main $@


### PR DESCRIPTION
This uses:

- [ShellCheck](https://www.shellcheck.net/)
- [shfmt](https://github.com/mvdan/sh)

behind the scenes.

After #1 is merged I don't mind either relaxing the rules or adapting the code. I've found, over use, that at least ShellCheck is very good at catching error-prone patterns and even helping make it more readable.

Closes #13.
Closes #14.