### PR TITLE
Drop version from release assets to easily download latest asset

### DIFF
--- a/.github/workflows/update_builds.yaml
+++ b/.github/workflows/update_builds.yaml
@@ -23,7 +23,7 @@ jobs:
       OTP_REF: "${{ inputs.otp-ref }}"
       OPENSSL_VERSION: "${{ inputs.openssl-version }}"
       WXWIDGETS_VERSION: "${{ inputs.wxwidgets-version }}"
-      TGZ: "${{ inputs.otp-ref-name }}-${{ inputs.target }}.tar.gz"
+      TGZ: "otp-${{ inputs.target }}.tar.gz"
       BUILDS_CSV: "builds/${{ inputs.target }}.csv"
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -63,22 +63,26 @@ Example `builds/aarch64-apple-darwin.csv` entry:
 
 Build download URLs follow this pattern:
 
-    https://github.com/erlef/otp_builds/releases/download/{ref_name}/{ref_name}-{target}.tar.gz
+    https://github.com/erlef/otp_builds/releases/download/{ref_name}/otp-{target}.tar.gz
 
 Where `{ref_name}` is the name of Erlang/OTP git tag or branch name and `{target}` is the target
 triple (e.g. `aarch64-apple-darwin`). The supported Erlang/OTP branches are `master` and `maint`.
 
 Example build URLs:
 
-* <https://github.com/erlef/otp_builds/releases/download/OTP-27.0.1/OTP-27.0.1-aarch64-apple-darwin.tar.gz>
-* <https://github.com/erlef/otp_builds/releases/download/master/master-x86_64-apple-darwin.tar.gz>
+* <https://github.com/erlef/otp_builds/releases/download/master/otp-x86_64-apple-darwin.tar.gz>
+* <https://github.com/erlef/otp_builds/releases/download/OTP-27.0.1/otp-aarch64-apple-darwin.tar.gz>
+
+To download from the _latest_ release, use this URL:
+
+* <https://github.com/erlef/otp_builds/releases/latest/download/otp-aarch64-apple-darwin.tar.gz>
 
 After downloading the build you should verify its integrity against builds csv mentioned in the
 previous section, for example:
 
-    curl -fLO https://github.com/erlef/otp_builds/releases/download/OTP-27.1.2/OTP-27.1.2-aarch64-apple-darwin.tar.gz
+    curl -fLO https://github.com/erlef/otp_builds/releases/download/OTP-27.1.2/otp-aarch64-apple-darwin.tar.gz
     checksum=$(curl -fsSL https://github.com/erlef/otp_builds/raw/main/builds/aarch64-apple-darwin.csv | grep OTP-27.1.2, | cut -d"," -f4)
-    sha256 OTP-27.1.2-aarch64-apple-darwin.tar.gz --check $checksum
+    sha256 otp-aarch64-apple-darwin.tar.gz --check $checksum
 
 ## License
 

--- a/scripts/upload.bash
+++ b/scripts/upload.bash
@@ -73,7 +73,7 @@ main() {
   esac
 
   mkdir -p /tmp/otp_builds
-  tgz="/tmp/otp_builds/${OTP_REF_NAME}-${target}.tar.gz"
+  tgz="/tmp/otp_builds/otp-${target}.tar.gz"
   cp "${OTP_TGZ}" "${tgz}"
   legacy_tgz="/tmp/otp_builds/${OTP_REF_NAME}-${legacy_target}.tar.gz"
   cp "${OTP_TGZ}" "${legacy_tgz}"


### PR DESCRIPTION
With this change this URL will work:

<https://github.com/erlef/otp_builds/releases/latest/download/otp-aarch64-apple-darwin.tar.gz>

Which is useful for tools that want to grab the latest release without knowing the exact version (grabbing it using GitHub REST API for example).

cc @tsloughter