### PR TITLE
fix: issue on building with Xcode 16.0+

### DIFF
--- a/scripts/build_otp_macos.bash
+++ b/scripts/build_otp_macos.bash
@@ -30,6 +30,8 @@ EOF
   export MAKEFLAGS="-j${n}"
   export CFLAGS="-Os -fno-common -mmacosx-version-min=11.0"
 
+  ulimit -n 65536
+
   build_openssl "${OPENSSL_VERSION}"
 
   if [[ "${WXWIDGETS_VERSION}" != disabled ]]; then


### PR DESCRIPTION
Hi,

I tested the building script taught by @wojtekmach

https://github.com/erlef/otp_builds/issues/41#issuecomment-2511384903

```zsh
$ gh repo clone erlef/otp_builds
$ cd otp_builds
$ sh scripts/build_otp_macos.bash OTP-27.1.2
$ tmp/otp_builds/otp-OTP-27.1.2-openssl-3.1.6-wxwidgets-3.2.6/bin/erl
Erlang/OTP 27 [erts-15.1.2] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [jit]

Eshell V15.1.2 (press Ctrl+G to abort, type help(). for help)
1>
```

Unfortunately, I got the following error:

```zsh
In file included from sys/unix/erl_unix_sys.h:65:
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/unistd.h:525:10: fatal error: cannot open file 'aarch64-apple-darwin/opt/jit/_ctermid.h': Too many open files
  525 | #include <_ctermid.h>
      |          ^
 CXX	obj/aarch64-apple-darwin/opt/jit/instr_map.o
1 error generated.
make[4]: *** [obj/aarch64-apple-darwin/opt/jit/beam_asm_module.o] Error 1
make[4]: *** Waiting for unfinished jobs....
make[3]: *** [opt] Error 2
make[2]: *** [opt] Error 2
make[1]: *** [jit] Error 2
make: *** [emulator] Error 2
```

Fortunately, I know how to fix this issue:

https://github.com/asdf-vm/asdf-erlang/issues/319

```zsh
ulimit -n 65536
```

This PR patches this on `scripts/build_otp_macos.bash`.

Thank you.
