### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,4 +1,6 @@
 name: Lint
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/erlef/otp_builds/security/code-scanning/2](https://github.com/erlef/otp_builds/security/code-scanning/2)

To fix the issue, add a `permissions` block to the workflow. Since this is a linting workflow, it only needs read access to the repository contents. The `permissions` block can be added at the root level of the workflow to apply to all jobs, or specifically to the `lint` job. In this case, adding it at the root level is more concise and ensures consistency across all jobs.

The `permissions` block will look like this:
```yaml
permissions:
  contents: read
```

This change ensures that the workflow only has the minimal permissions required to perform its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
