### PR TITLE
Update OpenSSL to 3.5.7

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,7 @@ on:
       otp-ref:
         required: true
       openssl-version:
-        default: "3.5.6"
+        default: "3.5.7"
       wxwidgets-version:
         default: "3.2.10"
       target:

--- a/scripts/build_otp_macos.bash
+++ b/scripts/build_otp_macos.bash
@@ -20,7 +20,7 @@ EOF
   esac
 
   : "${BUILD_DIR:=${PWD}/tmp/otp_builds}"
-  : "${OPENSSL_VERSION:=3.5.6}"
+  : "${OPENSSL_VERSION:=3.5.7}"
   : "${OPENSSL_DIR:=${BUILD_DIR}/openssl-${OPENSSL_VERSION}}"
   : "${WXWIDGETS_VERSION:=3.2.6}"
   : "${WXWIDGETS_DIR:=${BUILD_DIR}/wxwidgets-${WXWIDGETS_VERSION}}"


### PR DESCRIPTION
OpenSSL 3.5.7 was released today with some security patches: https://github.com/openssl/openssl/releases/tag/openssl-3.5.7